### PR TITLE
Update requirement validation in build workflow.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             echo "requirements.txt not found"
             exit 1
           fi
-          if grep -E "(^-|^git\+|^http)" requirements.txt; then
+          if grep -E "(^-|^git\+|^https?://)" requirements.txt; then
             echo "Potentially unsafe dependencies detected"
             exit 1
           fi  


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update requirement validation in build workflow. Now it will match real http(s) link and won't match and block dependency like `httpcore==1.0.9`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
