### PR TITLE
Fix: Pin DSPy to 2.6.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jinja2
 boto3
 botocore
 boto3-stubs
-dspy
+dspy==2.6.27
 numpy==2.3.1
 virtualenv==20.31.2
 urllib3==2.5.0


### PR DESCRIPTION
Issue #, if available:
DSPy versions 3.0+ introduce breaking changes that cause compatibility issues with the Nova Prompt Optimizer SDK:

    Changes to internal DSPy APIs that the SDK relies on
    Modified behavior in MIPROv2 optimizer integration
    Potential issues with structured output parsing

Description of changes:
Pin DSPy to version 2.6.27 in requirements.txt.

Raised by @tsanti